### PR TITLE
fix: crash message popping up when (stupid) software crashes at exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ function(sdk_launcher_configure_target TARGET)
 endfunction()
 
 # miniz
+set(BUILD_NO_STDIO ON CACHE INTERNAL "" FORCE)
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/miniz")
 
 # Qt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 # Create project
 project(sdk_launcher
         DESCRIPTION "A minimal SDK launcher for Strata Source engine games"
-        VERSION "0.4.1"
+        VERSION "0.4.2"
         HOMEPAGE_URL "https://github.com/StrataSource/sdk-launcher")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
- Crash message now only shows up if the process crashed in the first 30 seconds after launch
- Disable stdio functions in miniz
- Bump patch version to 0.4.2