### PR TITLE
Misc things

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,8 @@ add_executable(${PROJECT_TARGET_NAME} WIN32
         "${CMAKE_CURRENT_SOURCE_DIR}/src/NewModDialog.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/NewP2CEAddonDialog.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/NewP2CEAddonDialog.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/Steam.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/Steam.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Window.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Window.h")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 # Create project
 project(sdk_launcher
         DESCRIPTION "An SDK launcher for Strata Source engine games"
-        VERSION "0.5.3"
+        VERSION "0.6.0"
         HOMEPAGE_URL "https://github.com/StrataSource/sdk-launcher")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Here is an example config file that may be loaded into the SDK launcher.
 
 ```json5
 {
-  // The name of the game directory
+  // The name of the game directory (if relative), or an absolute path. If this field is an absolute path,
+  // the game_icon field (which assumes ${GAME} is relative) should be updated to prevent a missing logo.
+  // Use ${SOURCEMODS} to enter the SourceMods folder, for example "${SOURCEMODS}/mymod"
   "game_default": "p2ce",
   // Optional, the default is "${ROOT}/${GAME}/resource/game.ico"
   "game_icon": "${ROOT}/${GAME}/resource/game.ico",

--- a/res/config/p2ce.json
+++ b/res/config/p2ce.json
@@ -1,6 +1,6 @@
 {
   "game_default": "p2ce",
-  "window_height": 625,
+  "window_height": 647,
   "mod_template_url": "https://github.com/StrataSource/p2ce-mod-template/archive/refs/heads/main.zip",
   "supports_p2ce_addons": true,
   "sections": [
@@ -116,6 +116,11 @@
           "name": "SDK Tools",
           "type": "directory",
           "action": "${ROOT}/sdk_tools"
+        },
+        {
+          "name": "Steam SourceMods",
+          "type": "directory",
+          "action": "${SOURCEMODS}"
         }
       ]
     }

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -148,6 +148,7 @@ void GameConfig::setVariable(const QString& variable, const QString& replacement
 	const auto setVar = [&variable, &replacement](QString& str) {
 		str.replace(QString("${%1}").arg(variable), replacement);
 	};
+	setVar(this->gameDefault);
 	setVar(this->gameIcon);
 	for (auto& section : this->sections) {
 		setVar(section.name);

--- a/src/NewModDialog.cpp
+++ b/src/NewModDialog.cpp
@@ -21,87 +21,9 @@
 #include <QProgressDialog>
 #include <QStandardPaths>
 
-#ifdef _WIN32
-	#include <memory>
-	#include <Windows.h>
-#else
-	#include <cstdlib>
-#endif
+#include "Steam.h"
 
 namespace {
-
-/// Copied from sourcepp
-[[nodiscard]] QString getSourceModsDirLocationHelper() {
-	std::filesystem::path steamLocation;
-	std::error_code ec;
-
-#ifdef _WIN32
-	{
-		// 16383 being the maximum length of a path
-		static constexpr DWORD STEAM_LOCATION_MAX_SIZE = 16383;
-		std::unique_ptr<char[]> steamLocationData{new char[STEAM_LOCATION_MAX_SIZE]};
-
-		HKEY steam;
-		if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, R"(SOFTWARE\Valve\Steam)", 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &steam) != ERROR_SUCCESS) {
-			return "";
-		}
-
-		DWORD steamLocationSize = STEAM_LOCATION_MAX_SIZE;
-		if (RegQueryValueExA(steam, "InstallPath", nullptr, nullptr, reinterpret_cast<LPBYTE>(steamLocationData.get()), &steamLocationSize) != ERROR_SUCCESS) {
-			return "";
-		}
-
-		RegCloseKey(steam);
-		steamLocation = steamLocationSize > 0 ? std::string(steamLocationData.get(), steamLocationSize - 1) : "";
-	}
-#else
-	{
-		std::filesystem::path home{std::getenv("HOME")};
-#ifdef __APPLE__
-		steamLocation = home / "Library" / "Application Support" / "Steam";
-#else
-		// Snap install takes priority, the .steam symlink may exist simultaneously with Snap installs
-		steamLocation = home / "snap" / "steam" / "common" / ".steam" / "steam";
-
-		if (!std::filesystem::exists(steamLocation, ec)) {
-			// Use the regular install path
-			steamLocation = home / ".steam" / "steam";
-		}
-#endif
-	}
-
-	if (!std::filesystem::exists(steamLocation, ec)) {
-		std::string location;
-		std::filesystem::path d{"cwd/steamclient64.dll"};
-		for (const auto& entry : std::filesystem::directory_iterator{"/proc/"}) {
-			if (std::filesystem::exists(entry / d, ec)) {
-				ec.clear();
-				const auto s = std::filesystem::read_symlink(entry.path() / "cwd", ec);
-				if (ec) {
-					continue;
-				}
-				location = s.string();
-				break;
-			}
-		}
-		if (location.empty()) {
-			return "";
-		} else {
-			steamLocation = location;
-		}
-	}
-#endif
-
-	if (auto sourceModPath = (steamLocation / "steamapps" / "sourcemods").string(); std::filesystem::exists(sourceModPath, ec)) {
-		return sourceModPath.c_str();
-	}
-	return "";
-}
-
-[[nodiscard]] const QString& getSourceModsDirLocation() {
-	static QString location = ::getSourceModsDirLocationHelper();
-	return location;
-}
 
 [[nodiscard]] QString join(const QStringList& list, const QString& separator) {
 	if (list.isEmpty()) {
@@ -217,7 +139,7 @@ NewModDialog::NewModDialog(QString gameRoot_, QString downloadURL_, QWidget* par
 		, gameRoot(std::move(gameRoot_))
 		, downloadURL(std::move(downloadURL_)) {
 	// Check for sourcemods
-	const bool knowsSourcemodsDirLocation = !::getSourceModsDirLocation().isEmpty();
+	const bool knowsSourcemodsDirLocation = !::getSourceModsDir().isEmpty();
 
 	// Window setup
 	this->setModal(true);
@@ -352,7 +274,7 @@ QString NewModDialog::getModInstallDirParent() const {
 	}
 	switch (selectedIndex) {
 		case 0:
-			return ::getSourceModsDirLocation();
+			return ::getSourceModsDir();
 		case 1:
 			return this->gameRoot;
 		default:

--- a/src/Steam.cpp
+++ b/src/Steam.cpp
@@ -1,0 +1,86 @@
+#include "Steam.h"
+
+#include <filesystem>
+#ifdef _WIN32
+	#include <memory>
+	#include <Windows.h>
+#else
+	#include <cstdlib>
+#endif
+
+namespace {
+
+/// Copied from sourcepp
+[[nodiscard]] QString getSourceModsDirHelper() {
+	std::filesystem::path steamLocation;
+	std::error_code ec;
+
+#ifdef _WIN32
+	{
+		// 16383 being the maximum length of a path
+		static constexpr DWORD STEAM_LOCATION_MAX_SIZE = 16383;
+		std::unique_ptr<char[]> steamLocationData{new char[STEAM_LOCATION_MAX_SIZE]};
+
+		HKEY steam;
+		if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, R"(SOFTWARE\Valve\Steam)", 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &steam) != ERROR_SUCCESS) {
+			return "";
+		}
+
+		DWORD steamLocationSize = STEAM_LOCATION_MAX_SIZE;
+		if (RegQueryValueExA(steam, "InstallPath", nullptr, nullptr, reinterpret_cast<LPBYTE>(steamLocationData.get()), &steamLocationSize) != ERROR_SUCCESS) {
+			return "";
+		}
+
+		RegCloseKey(steam);
+		steamLocation = steamLocationSize > 0 ? std::string(steamLocationData.get(), steamLocationSize - 1) : "";
+	}
+#else
+	{
+		std::filesystem::path home{std::getenv("HOME")};
+#ifdef __APPLE__
+		steamLocation = home / "Library" / "Application Support" / "Steam";
+#else
+		// Snap install takes priority, the .steam symlink may exist simultaneously with Snap installs
+		steamLocation = home / "snap" / "steam" / "common" / ".steam" / "steam";
+
+		if (!std::filesystem::exists(steamLocation, ec)) {
+			// Use the regular install path
+			steamLocation = home / ".steam" / "steam";
+		}
+#endif
+	}
+
+	if (!std::filesystem::exists(steamLocation, ec)) {
+		std::string location;
+		std::filesystem::path d{"cwd/steamclient64.dll"};
+		for (const auto& entry : std::filesystem::directory_iterator{"/proc/"}) {
+			if (std::filesystem::exists(entry / d, ec)) {
+				ec.clear();
+				const auto s = std::filesystem::read_symlink(entry.path() / "cwd", ec);
+				if (ec) {
+					continue;
+				}
+				location = s.string();
+				break;
+			}
+		}
+		if (location.empty()) {
+			return "";
+		} else {
+			steamLocation = location;
+		}
+	}
+#endif
+
+	if (auto sourceModPath = (steamLocation / "steamapps" / "sourcemods").string(); std::filesystem::exists(sourceModPath, ec)) {
+		return sourceModPath.c_str();
+	}
+	return "";
+}
+
+} // namespace
+
+const QString& getSourceModsDir() {
+	static QString location = ::getSourceModsDirHelper();
+	return location;
+}

--- a/src/Steam.h
+++ b/src/Steam.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <QString>
+
+[[nodiscard]] const QString& getSourceModsDir();

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -21,6 +21,7 @@
 #include "LaunchButton.h"
 #include "NewModDialog.h"
 #include "NewP2CEAddonDialog.h"
+#include "Steam.h"
 
 #ifdef _WIN32
 #include <shlobj_core.h>
@@ -226,6 +227,9 @@ void Window::loadGameConfig(const QString& path) {
 	}
 	settings.setValue(STR_RECENT_CONFIGS, recentConfigs);
 	this->regenerateRecentConfigs();
+
+	// Set ${SOURCEMODS}
+	gameConfig->setVariable("SOURCEMODS", ::getSourceModsDir());
 
 	// Set ${ROOT}
 	const auto rootPath = ::getRootPath(this->configUsingLegacyBinDir);

--- a/src/Window.h
+++ b/src/Window.h
@@ -20,13 +20,14 @@ public:
 	void regenerateRecentConfigs();
 
 private:
+	QString gameDefault;
 	bool configUsingLegacyBinDir;
 	QString configModTemplateURL;
 
 	QMenu* recent;
 	QAction* config_loadDefault;
-	QAction* game_resetToDefault;
 	QAction* game_overrideGame;
+	QAction* game_resetToDefault;
 	QAction* utilities_createNewMod;
 	QAction* utilities_createNewAddon;
 


### PR DESCRIPTION
- `${SOURCEMODS}` config variable: the absolute path of the sourcemods folder
- Apply variables to `game_default` field
- Add sourcemods folder to Quick Access
- Use `game_default` field everywhere when a config is loaded instead of the compiled default game
- Don't assume `${GAME}` is relative to `${ROOT}` in hardcoded locations (default `game_icon` path is fine)