### PR TITLE
Add verbose I/O + logfile launcher configs and fix incorrect exe path for Revo safe mode

### DIFF
--- a/res/config/momentum.json
+++ b/res/config/momentum.json
@@ -11,15 +11,22 @@
           "arguments": ["-game", "${GAME}", "-dev", "-console"],
           "icon_override": "${GAME_ICON}"
         },
-		{
-          "name": "Momentum Mod - Dev Mode (Verbose Entity I/O and Logfile)",
+        {
+          "name": "Momentum Mod - Dev Mode (Verbose Entity I/O && Log to File)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/momentum",
           "arguments": ["-game", "${GAME}", "-dev", "+developer 2", "-console", "-condebug"],
           "icon_override": "${GAME_ICON}"
         },
         {
-          "name": "Momentum Mod - Safe Mode (No Custom Content)",
+          "name": "Momentum Mod - Tools Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/momentum",
+          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
+          "icon_override": "${GAME_ICON}"
+        },
+        {
+          "name": "Momentum Mod - Safe Mode (No Mounted Content)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/momentum",
           "arguments": ["-game", "${GAME}", "-nousermount", "-nocustommount"],
@@ -49,13 +56,6 @@
           "action": "${ROOT}/bin/win64/hlfaceposer",
           "arguments": ["-game", "${GAME}"],
           "os": "windows"
-        },
-        {
-          "name": "Engine Tools Mode",
-          "type": "command",
-          "action": "${ROOT}/bin/${PLATFORM}/momentum",
-          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
-          "icon_override": "${GAME_ICON}"
         }
       ]
     },

--- a/res/config/momentum.json
+++ b/res/config/momentum.json
@@ -11,11 +11,11 @@
           "arguments": ["-game", "${GAME}", "-dev", "-console"],
           "icon_override": "${GAME_ICON}"
         },
-        {
-          "name": "Momentum Mod - Dev && Tools Mode",
+		{
+          "name": "Momentum Mod - Dev Mode (Verbose Entity I/O and Logfile)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/momentum",
-          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
+          "arguments": ["-game", "${GAME}", "-dev", "+developer 2", "-console", "-condebug"],
           "icon_override": "${GAME_ICON}"
         },
         {
@@ -49,6 +49,13 @@
           "action": "${ROOT}/bin/win64/hlfaceposer",
           "arguments": ["-game", "${GAME}"],
           "os": "windows"
+        },
+        {
+          "name": "Engine Tools Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/momentum",
+          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
+          "icon_override": "${GAME_ICON}"
         }
       ]
     },

--- a/res/config/p2ce.json
+++ b/res/config/p2ce.json
@@ -15,14 +15,14 @@
           "icon_override": "${GAME_ICON}"
         },
         {
-          "name": "Portal 2: CE - Dev && Tools Mode",
+          "name": "Portal 2: CE - Dev Mode (Verbose Entity I/O and Logfile)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/p2ce",
-          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
+          "arguments": ["-game", "${GAME}", "-dev", "+developer 2", "-console", "-condebug"],
           "icon_override": "${GAME_ICON}"
         },
         {
-          "name": "Portal 2: CE - Safe Mode",
+          "name": "Portal 2: CE - Safe Mode (No Custom Content)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/p2ce",
           "arguments": ["-game", "${GAME}", "-nousermount", "-nocustommount"],
@@ -52,6 +52,13 @@
           "action": "${ROOT}/bin/win64/hlfaceposer",
           "arguments": ["-game", "${GAME}"],
           "os": "windows"
+        },
+        {
+          "name": "Engine Tools Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/p2ce",
+          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
+          "icon_override": "${GAME_ICON}"
         },
         {
           "name": "VPKEdit",

--- a/res/config/p2ce.json
+++ b/res/config/p2ce.json
@@ -15,14 +15,21 @@
           "icon_override": "${GAME_ICON}"
         },
         {
-          "name": "Portal 2: CE - Dev Mode (Verbose Entity I/O and Logfile)",
+          "name": "Portal 2: CE - Dev Mode (Verbose Entity I/O && Log to File)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/p2ce",
           "arguments": ["-game", "${GAME}", "-dev", "+developer 2", "-console", "-condebug"],
           "icon_override": "${GAME_ICON}"
         },
         {
-          "name": "Portal 2: CE - Safe Mode (No Custom Content)",
+          "name": "Portal 2: CE - Tools Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/p2ce",
+          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
+          "icon_override": "${GAME_ICON}"
+        },
+        {
+          "name": "Portal 2: CE - Safe Mode (No Mounted Content)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/p2ce",
           "arguments": ["-game", "${GAME}", "-nousermount", "-nocustommount"],
@@ -52,14 +59,7 @@
           "action": "${ROOT}/bin/win64/hlfaceposer",
           "arguments": ["-game", "${GAME}"],
           "os": "windows"
-        },
-        {
-          "name": "Engine Tools Mode",
-          "type": "command",
-          "action": "${ROOT}/bin/${PLATFORM}/p2ce",
-          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
-          "icon_override": "${GAME_ICON}"
-        },
+        }
         {
           "name": "VPKEdit",
           "type": "command",

--- a/res/config/revolution.json
+++ b/res/config/revolution.json
@@ -89,6 +89,11 @@
           "name": "SDK Content",
           "type": "directory",
           "action": "${ROOT}/sdk_content"
+        },
+        {
+          "name": "Steam SourceMods",
+          "type": "directory",
+          "action": "${SOURCEMODS}"
         }
       ]
     }

--- a/res/config/revolution.json
+++ b/res/config/revolution.json
@@ -12,10 +12,17 @@
           "icon_override": "${GAME_ICON}"
         },
         {
-          "name": "Portal 2: CE - Dev Mode (Verbose Entity I/O and Logfile)",
+          "name": "Portal: Revolution - Dev Mode (Verbose Entity I/O && Log to File)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/revolution",
           "arguments": ["-game", "${GAME}", "-dev", "+developer 2", "-console", "-condebug"],
+          "icon_override": "${GAME_ICON}"
+        },
+        {
+          "name": "Portal: Revolution - Tools Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/revolution",
+          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
           "icon_override": "${GAME_ICON}"
         },
         {
@@ -49,13 +56,6 @@
           "action": "${ROOT}/bin/win64/hlfaceposer",
           "arguments": ["-game", "${GAME}"],
           "os": "windows"
-        },
-        {
-          "name": "Engine Tools Mode",
-          "type": "command",
-          "action": "${ROOT}/bin/${PLATFORM}/revolution",
-          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
-          "icon_override": "${GAME_ICON}"
         }
       ]
     },

--- a/res/config/revolution.json
+++ b/res/config/revolution.json
@@ -12,16 +12,16 @@
           "icon_override": "${GAME_ICON}"
         },
         {
-          "name": "Portal: Revolution - Dev && Tools Mode",
+          "name": "Portal 2: CE - Dev Mode (Verbose Entity I/O and Logfile)",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/revolution",
-          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
+          "arguments": ["-game", "${GAME}", "-dev", "+developer 2", "-console", "-condebug"],
           "icon_override": "${GAME_ICON}"
         },
         {
           "name": "Portal: Revolution - Safe Mode (No Custom Content)",
           "type": "command",
-          "action": "${ROOT}/bin/${PLATFORM}/chaos",
+          "action": "${ROOT}/bin/${PLATFORM}/revolution",
           "arguments": ["-game", "${GAME}", "-nousermount", "-nocustommount"],
           "icon_override": "${GAME_ICON}"
         }
@@ -49,6 +49,13 @@
           "action": "${ROOT}/bin/win64/hlfaceposer",
           "arguments": ["-game", "${GAME}"],
           "os": "windows"
+        },
+        {
+          "name": "Engine Tools Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/revolution",
+          "arguments": ["-game", "${GAME}", "-dev", "-console", "-tools"],
+          "icon_override": "${GAME_ICON}"
         }
       ]
     },
@@ -72,6 +79,16 @@
           "type": "link",
           "action": "https://github.com/StrataSource/Engine/issues",
           "icon_override": "${STRATA_ICON}"
+        }
+      ]
+    },
+    {
+      "name": "Quick Access",
+      "entries": [
+        {
+          "name": "SDK Content",
+          "type": "directory",
+          "action": "${ROOT}/sdk_content"
         }
       ]
     }


### PR DESCRIPTION
Adds a new option for all Strata games that enables `developer 2` (which spews entity I/O in addition to extra debugging info), ~~moves the engine tools mode option to the appropriate "Tools" section~~ and fixes a typo where Revo safe mode used the wrong exe name (preventing launch).