### PR TITLE
Add "Default Mode" to SDK Launcher

### DIFF
--- a/res/config/momentum.json
+++ b/res/config/momentum.json
@@ -7,6 +7,13 @@
       "name": "Game",
       "entries": [
         {
+          "name": "Momentum Mod - Default Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/momentum",
+          "arguments": ["-game", "${GAME}", "-console"],
+          "icon_override": "${GAME_ICON}"
+        },
+        {
           "name": "Momentum Mod - Dev Mode",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/momentum",

--- a/res/config/p2ce.json
+++ b/res/config/p2ce.json
@@ -12,6 +12,13 @@
       "name": "Game",
       "entries": [
         {
+          "name": "Portal 2: CE - Default Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/p2ce",
+          "arguments": ["-game", "${GAME}", "-console"],
+          "icon_override": "${GAME_ICON}"
+        },
+        {
           "name": "Portal 2: CE - Dev Mode",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/p2ce",

--- a/res/config/revolution.json
+++ b/res/config/revolution.json
@@ -7,6 +7,13 @@
       "name": "Game",
       "entries": [
         {
+          "name": "Portal: Revolution - Default Mode",
+          "type": "command",
+          "action": "${ROOT}/bin/${PLATFORM}/revolution",
+          "arguments": ["-game", "${GAME}", "-console"],
+          "icon_override": "${GAME_ICON}"
+        },
+        {
           "name": "Portal: Revolution - Dev Mode",
           "type": "command",
           "action": "${ROOT}/bin/${PLATFORM}/revolution",


### PR DESCRIPTION
Whenever the SDK launcher is opened and (for example) Hammer is open, Steam indicates both the SDK and the game to be "running".

<img width="616" height="486" alt="image" src="https://github.com/user-attachments/assets/996285c7-fd28-4944-950c-cd88cca2c9a8" />

Even when the game is not opened (eg in dev mode) this means that the game cannot be opened in default mode (non-dev, non-tools). In some cases though, you do want to work on something and open the game in default mode (I like to compile a map and test it in dev mode and afterwards make some screenshots / a screen recording in default mode). But for this you'd have to open the games folder and manually start the engine exe.

This PR adds a little shortcut that just opens the game without tools mode and dev mode so it's more convenient.